### PR TITLE
Create shared ChatMessage interface

### DIFF
--- a/src/common/interfaces/chat-message.ts
+++ b/src/common/interfaces/chat-message.ts
@@ -1,0 +1,4 @@
+export interface ChatMessage {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}

--- a/src/openai/openai.service.ts
+++ b/src/openai/openai.service.ts
@@ -2,12 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
 import { ChatCompletionTool } from 'openai/resources/chat/completions';
-
-// Interfaz para el historial de chat (útil en ambos servicios)
-interface ChatMessage {
-  role: 'user' | 'assistant' | 'system';
-  content: string;
-}
+import { ChatMessage } from '../common/interfaces/chat-message';
 
 @Injectable()
 export class OpenaiService {

--- a/src/whatsapp-webhook/whatsapp-webhook.controller.ts
+++ b/src/whatsapp-webhook/whatsapp-webhook.controller.ts
@@ -3,12 +3,7 @@ import { Request, Response } from 'express';
 import { OpenaiService } from '../openai/openai.service';
 import { WhatsappService } from '../whatsapp/whatsapp.service';
 import chalk from 'chalk';
-
-// Interfaz para el historial de chat (DEBE ESTAR DEFINIDA EN ESTE ARCHIVO TAMBIÉN)
-interface ChatMessage {
-  role: 'user' | 'assistant' | 'system';
-  content: string;
-}
+import { ChatMessage } from '../common/interfaces/chat-message';
 
 // Interfaz para el payload del webhook de WhatsApp (tu definición existente)
 interface WhatsAppMessagePayload {


### PR DESCRIPTION
## Summary
- add common ChatMessage interface
- use shared interface in OpenAI service
- use shared interface in webhook controller

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685935409a90832aa3571dd232779fe9