### PR TITLE
Refactor webhook controller

### DIFF
--- a/src/whatsapp-webhook/whatsapp-webhook.controller.spec.ts
+++ b/src/whatsapp-webhook/whatsapp-webhook.controller.spec.ts
@@ -9,7 +9,9 @@ describe('WhatsappWebhookController', () => {
       controllers: [WhatsappWebhookController],
     }).compile();
 
-    controller = module.get<WhatsappWebhookController>(WhatsappWebhookController);
+    controller = module.get<WhatsappWebhookController>(
+      WhatsappWebhookController,
+    );
   });
 
   it('should be defined', () => {

--- a/src/whatsapp-webhook/whatsapp-webhook.controller.ts
+++ b/src/whatsapp-webhook/whatsapp-webhook.controller.ts
@@ -84,9 +84,119 @@ export class WhatsappWebhookController {
   private processedMessageIds = new Set<string>();
   private readonly DEDUPE_TTL_MS = 60 * 1000; // Mantener IDs por 60 segundos
 
+  private isDuplicate(eventId: string): boolean {
+    if (this.processedMessageIds.has(eventId)) {
+      return true;
+    }
+    this.processedMessageIds.add(eventId);
+    setTimeout(
+      () => this.processedMessageIds.delete(eventId),
+      this.DEDUPE_TTL_MS,
+    );
+    return false;
+  }
+
   // **ALMACENAMIENTO DEL HISTORIAL DE CONVERSACIÓN EN MEMORIA (PARA PRUEBAS LOCALES)**
   private conversationHistory = new Map<string, ChatMessage[]>();
   private readonly MAX_CHAT_HISTORY_LENGTH = 10; // Limitar el historial para el LLM (5 pares de turno)
+
+  private async processIncomingMessage(
+    from: string,
+    textBody: string,
+  ): Promise<void> {
+    console.log(chalk.blue(`[Recibido] Mensaje de ${from}: ${textBody}`));
+
+    const currentChatHistory = this.conversationHistory.get(from) || [];
+    currentChatHistory.push({ role: 'user', content: textBody });
+
+    const aiResponse = await this.openAIService.getAIResponse(
+      textBody,
+      currentChatHistory,
+    );
+
+    if (currentChatHistory.length > this.MAX_CHAT_HISTORY_LENGTH) {
+      currentChatHistory.splice(
+        0,
+        currentChatHistory.length - this.MAX_CHAT_HISTORY_LENGTH,
+      );
+    }
+    this.conversationHistory.set(from, currentChatHistory);
+
+    if (typeof aiResponse === 'object' && 'tool_call' in aiResponse) {
+      const toolCallObject = aiResponse.tool_call as ToolCallObject;
+      console.log(
+        chalk.cyan(
+          `[AGENTE] Respuesta de IA con tool_call: ${JSON.stringify(
+            toolCallObject,
+          )}`,
+        ),
+      );
+      if (toolCallObject && typeof toolCallObject === 'object') {
+        const toolName = toolCallObject.name;
+        let toolArgs: any;
+        if (typeof toolCallObject.arguments === 'string') {
+          toolArgs = JSON.parse(toolCallObject.arguments);
+        } else {
+          toolArgs = toolCallObject.arguments;
+        }
+
+        console.log(
+          chalk.magenta(
+            `[AGENTE] ¡Preparando para ejecutar herramienta: ${toolName} con argumentos: ${JSON.stringify(
+              toolArgs,
+            )}`,
+          ),
+        );
+
+        let whatsappReply = '';
+        if (toolName === 'Gmail_Send') {
+          const gmailArgs = toolArgs as GmailSendArgs;
+          const recipientDisplay = gmailArgs.recipient_name
+            ? `${gmailArgs.recipient_name} (${gmailArgs.recipient})`
+            : gmailArgs.recipient;
+          whatsappReply = `¡Excelente! He preparado el correo para ${recipientDisplay} con el asunto "${gmailArgs.subject}". Se enviará con el siguiente contenido:\n\n---\n${gmailArgs.body}\n---.\n\nRecuerda que esta es una simulación. Para el envío real, deberías integrar la API de Gmail aquí.`;
+        } else if (toolName === 'Calendar_Set') {
+          const calendarSetArgs = toolArgs as CalendarSetArgs;
+          whatsappReply = `¡Listo! He simulado la programación de "${calendarSetArgs.title}" para el ${calendarSetArgs.date} a las ${calendarSetArgs.time}.`;
+        } else if (toolName === 'Calendar_Get') {
+          const calendarGetArgs = toolArgs as CalendarGetArgs;
+          whatsappReply = `Simulando la consulta del calendario para ${calendarGetArgs.date || 'hoy'}.`;
+        } else {
+          whatsappReply =
+            'Lo siento, la IA me dio una instrucción de herramienta que no reconozco en esta simulación.';
+        }
+
+        await this.whatsappService.sendMessage(from, whatsappReply);
+        currentChatHistory.push({
+          role: 'assistant',
+          content: whatsappReply,
+        });
+      } else {
+        console.warn(
+          chalk.yellow(
+            `[WARN] 'tool_call' encontrado, pero sin propiedad 'function' esperada. Respondiendo conversacionalmente.`,
+          ),
+        );
+        await this.whatsappService.sendMessage(
+          from,
+          'Lo siento, la IA intentó usar una herramienta, pero hubo un problema interno con la instrucción. Por favor, inténtalo de nuevo.',
+        );
+        currentChatHistory.push({
+          role: 'assistant',
+          content:
+            'Lo siento, la IA intentó usar una herramienta, pero hubo un problema interno con la instrucción. Por favor, inténtalo de nuevo.',
+        });
+      }
+    } else {
+      await this.whatsappService.sendMessage(from, aiResponse as string);
+      currentChatHistory.push({
+        role: 'assistant',
+        content: aiResponse as string,
+      });
+    }
+
+    console.log(chalk.green(`[Enviado] Respuesta del asistente a ${from}.`));
+  }
 
   @Get('webhook')
   verifyWebhook(@Req() req: Request, @Res() res: Response) {
@@ -121,165 +231,37 @@ export class WhatsappWebhookController {
         return res.status(200).send('EVENT_RECEIVED');
       }
 
-      // --- Lógica de Deduplicación ---
-      let eventIdToDeduplicate: string | undefined;
-      let fromNumber: string | undefined; // Para obtener el número del remitente y gestionar el historial
-
       if (change.field === 'messages') {
         const messages = change.value?.messages;
         const statuses = change.value?.statuses;
 
         if (messages && messages.length > 0) {
-          eventIdToDeduplicate = messages[0].id;
-          fromNumber = messages[0].from; // Obtener el número de WhatsApp del remitente
+          const { id, from, text } = messages[0];
 
-          if (this.processedMessageIds.has(eventIdToDeduplicate)) {
+          if (this.isDuplicate(id)) {
             console.warn(
               chalk.yellow(
-                `[DEDUPE] Mensaje de usuario duplicado/reintentado "${eventIdToDeduplicate}" detectado y omitido.`,
+                `[DEDUPE] Mensaje de usuario duplicado/reintentado "${id}" detectado y omitido.`,
               ),
             );
             return res.status(200).send('EVENT_RECEIVED');
           }
-          this.processedMessageIds.add(eventIdToDeduplicate);
-          setTimeout(
-            () => this.processedMessageIds.delete(eventIdToDeduplicate!),
-            this.DEDUPE_TTL_MS,
-          );
-
-          const message = messages[0];
-          const { from, text } = message;
 
           if (!from || !text?.body) {
             console.error(
-              chalk.red('Datos de mensaje entrante incompletos:', message),
+              chalk.red('Datos de mensaje entrante incompletos:', messages[0]),
             );
             return res.status(200).json({ error: 'Incomplete message data' });
           }
 
-          console.log(
-            chalk.blue(`[Recibido] Mensaje de ${from}: ${text.body}`),
-          );
-
-          // --- Gestión del Historial de Conversación en memoria ---
-          const currentChatHistory = this.conversationHistory.get(from) || [];
-          currentChatHistory.push({ role: 'user', content: text.body });
-
-          // LLAMADA A LA IA: PASANDO EL HISTORIAL COMPLETO
-          const aiResponse = await this.openAIService.getAIResponse(
-            text.body,
-            currentChatHistory,
-          );
-
-          // Limitar el historial antes de guardarlo de nuevo en la Map
-          if (currentChatHistory.length > this.MAX_CHAT_HISTORY_LENGTH) {
-            currentChatHistory.splice(
-              0,
-              currentChatHistory.length - this.MAX_CHAT_HISTORY_LENGTH,
-            );
-          }
-          this.conversationHistory.set(from, currentChatHistory);
-
-          if (typeof aiResponse === 'object' && 'tool_call' in aiResponse) {
-            const toolCallObject = aiResponse.tool_call as ToolCallObject;
-            console.log(
-              chalk.cyan(
-                `[AGENTE] Respuesta de IA con tool_call: ${JSON.stringify(
-                  toolCallObject,
-                )}`,
-              ),
-            );
-            // Verificación y casting seguro para ChatCompletionToolCall
-            if (toolCallObject && typeof toolCallObject === 'object') {
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              const toolName = toolCallObject.name;
-              // Asegurarse de que arguments es string antes de parsear
-              let toolArgs: any;
-              if (typeof toolCallObject.arguments === 'string') {
-                toolArgs = JSON.parse(toolCallObject.arguments); // Parsear el string JSON a objeto
-              } else {
-                toolArgs = toolCallObject.arguments; // Si ya es objeto, usarlo directamente
-              }
-
-              console.log(
-                chalk.magenta(
-                  `[AGENTE] ¡Preparando para ejecutar herramienta: ${toolName} con argumentos: ${JSON.stringify(toolArgs)}`,
-                ),
-              );
-
-              let whatsappReply = '';
-              if (toolName === 'Gmail_Send') {
-                const gmailArgs = toolArgs as GmailSendArgs; // Casting a interfaz específica
-                const recipientDisplay = gmailArgs.recipient_name
-                  ? `${gmailArgs.recipient_name} (${gmailArgs.recipient})`
-                  : gmailArgs.recipient;
-                whatsappReply = `¡Excelente! He preparado el correo para ${recipientDisplay} con el asunto "${gmailArgs.subject}". Se enviará con el siguiente contenido:\n\n---\n${gmailArgs.body}\n---.\n\nRecuerda que esta es una simulación. Para el envío real, deberías integrar la API de Gmail aquí.`;
-              } else if (toolName === 'Calendar_Set') {
-                const calendarSetArgs = toolArgs as CalendarSetArgs; // Casting a interfaz específica
-                whatsappReply = `¡Listo! He simulado la programación de "${calendarSetArgs.title}" para el ${calendarSetArgs.date} a las ${calendarSetArgs.time}.`;
-              } else if (toolName === 'Calendar_Get') {
-                const calendarGetArgs = toolArgs as CalendarGetArgs; // Casting a interfaz específica
-                whatsappReply = `Simulando la consulta del calendario para ${calendarGetArgs.date || 'hoy'}.`;
-              } else {
-                whatsappReply =
-                  'Lo siento, la IA me dio una instrucción de herramienta que no reconozco en esta simulación.';
-              }
-
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-              await this.whatsappService.sendMessage(from, whatsappReply);
-              currentChatHistory.push({
-                role: 'assistant',
-                content: whatsappReply,
-              });
-            } else {
-              console.warn(
-                chalk.yellow(
-                  `[WARN] 'tool_call' encontrado, pero sin propiedad 'function' esperada. Respondiendo conversacionalmente.`,
-                ),
-              );
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-              await this.whatsappService.sendMessage(
-                from,
-                'Lo siento, la IA intentó usar una herramienta, pero hubo un problema interno con la instrucción. Por favor, inténtalo de nuevo.',
-              );
-              currentChatHistory.push({
-                role: 'assistant',
-                content:
-                  'Lo siento, la IA intentó usar una herramienta, pero hubo un problema interno con la instrucción. Por favor, inténtalo de nuevo.',
-              });
-            }
-          } else {
-            // Es un mensaje conversacional (texto plano de la IA)
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-            await this.whatsappService.sendMessage(from, aiResponse as string);
-            currentChatHistory.push({
-              role: 'assistant',
-              content: aiResponse as string,
-            });
-          }
-
-          console.log(
-            chalk.green(`[Enviado] Respuesta del asistente a ${from}.`),
-          );
+          await this.processIncomingMessage(from, text.body);
           return res.status(200).send('EVENT_RECEIVED');
         } else if (statuses && statuses.length > 0) {
-          eventIdToDeduplicate = statuses[0].id;
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          fromNumber = statuses[0].recipient_id;
+          const eventId = statuses[0].id;
 
-          if (this.processedMessageIds.has(eventIdToDeduplicate)) {
-            /*console.warn(
-              chalk.yellow(
-                `[DEDUPE] Actualización de estado duplicada/reintentada "${eventIdToDeduplicate}" detectado y omitida.`,
-              ),
-            );*/
+          if (this.isDuplicate(eventId)) {
             return res.status(200).send('EVENT_RECEIVED');
           }
-          this.processedMessageIds.add(eventIdToDeduplicate);
-          setTimeout(
-            () => this.processedMessageIds.delete(eventIdToDeduplicate!),
-            this.DEDUPE_TTL_MS,
-          );
 
           const status = statuses[0];
           console.log(
@@ -289,30 +271,13 @@ export class WhatsappWebhookController {
           );
 
           if (status.pricing) {
-            /* console.log(
-              chalk.magenta(
-                `  [Precios] Billable: ${status.pricing.billable}, Categoría: ${status.pricing.category}, Modelo: ${status.pricing.pricing_model}`,
-              ),
-            );*/
             if (status.pricing.billable === true) {
-              /*  console.warn(
+              /* console.warn(
                 chalk.bold.red(
                   `  !!! Atención: Este mensaje (${status.id}) generó un costo. Categoría: ${status.pricing.category} !!!`,
                 ),
               );*/
-            } else {
-              /*console.log(
-                chalk.green(
-                  `  Este mensaje (${status.id}) NO generó un costo. Categoría: ${status.pricing.category}.`,
-                ),
-              );*/
             }
-          } else {
-            /*console.log(
-              chalk.gray(
-                '  No se encontró información de pricing para esta actualización de estado.',
-              ),
-            );*/
           }
 
           return res.status(200).send('EVENT_RECEIVED');


### PR DESCRIPTION
## Summary
- extract dedupe check into `isDuplicate`
- create `processIncomingMessage` to handle chat history and OpenAI call
- simplify `receiveMessage` to orchestrate other methods
- run prettier

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run format`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593548a638832abf9431921be02629