### PR TITLE
Use Google API for email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
         "axios": "^1.10.0",
+        "googleapis": "^134.0.0",
         "openai": "^5.5.1",
         "rxjs": "^7.8.1"
       },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
     "axios": "^1.10.0",
+    "googleapis": "^134.0.0",
     "openai": "^5.5.1",
     "rxjs": "^7.8.1"
   },

--- a/src/email/email.service.ts
+++ b/src/email/email.service.ts
@@ -1,17 +1,26 @@
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import axios from 'axios';
+import { google } from 'googleapis';
+import { OAuth2Client } from 'google-auth-library';
 
 @Injectable()
 export class EmailService {
-  private readonly gmailToken: string;
   private readonly fromEmail: string;
-  private readonly gmailApiUrl =
-    'https://gmail.googleapis.com/gmail/v1/users/me/messages/send';
+  private readonly oauth2Client: OAuth2Client;
 
   constructor(private readonly configService: ConfigService) {
-    this.gmailToken = this.configService.get<string>('GMAIL_ACCESS_TOKEN') || '';
+    const clientId = this.configService.get<string>('GMAIL_CLIENT_ID');
+    const clientSecret = this.configService.get<string>('GMAIL_CLIENT_SECRET');
+    const refreshToken = this.configService.get<string>('GMAIL_REFRESH_TOKEN');
+    const redirectUri = this.configService.get<string>('GMAIL_REDIRECT_URI');
     this.fromEmail = this.configService.get<string>('GMAIL_FROM_EMAIL') || '';
+
+    if (!clientId || !clientSecret || !refreshToken || !redirectUri) {
+      throw new Error('Missing Gmail OAuth2 credentials');
+    }
+
+    this.oauth2Client = new OAuth2Client(clientId, clientSecret, redirectUri);
+    this.oauth2Client.setCredentials({ refresh_token: refreshToken });
   }
 
   async sendEmail(
@@ -34,16 +43,11 @@ export class EmailService {
       .replace(/\//g, '_')
       .replace(/=+$/, '');
 
-    const response = await axios.post(
-      this.gmailApiUrl,
-      { raw: encodedMessage },
-      {
-        headers: {
-          Authorization: `Bearer ${this.gmailToken}`,
-          'Content-Type': 'application/json',
-        },
-      },
-    );
+    const gmail = google.gmail({ version: 'v1', auth: this.oauth2Client });
+    const response = await gmail.users.messages.send({
+      userId: 'me',
+      requestBody: { raw: encodedMessage },
+    });
 
     return response.data;
   }


### PR DESCRIPTION
## Summary
- add `googleapis` as a dependency
- switch `EmailService` to OAuth2 credentials from env and Google API client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859420574e0832a8ba74becc4e45941