### PR TITLE
Remove unused ChatMessage interface

### DIFF
--- a/src/common/interfaces/chat-message.ts
+++ b/src/common/interfaces/chat-message.ts
@@ -1,4 +1,0 @@
-export interface ChatMessage {
-  role: 'user' | 'assistant' | 'system';
-  content: string;
-}

--- a/src/whatsapp-webhook/whatsapp-webhook.controller.ts
+++ b/src/whatsapp-webhook/whatsapp-webhook.controller.ts
@@ -5,13 +5,6 @@ import chalk from 'chalk';
 
 import { WhatsappService } from '../whatsapp/whatsapp.service';
 
-// Si ChatMessage está en `src/common/interfaces/chat-message.ts`, puedes importarla desde allí
-// Si la dejaste dentro de agent.service.ts, te sugiero moverla a un archivo compartido
-// como src/common/interfaces/chat-message.ts para que ambos servicios puedan usarla.
-export interface ChatMessage {
-  role: 'user' | 'assistant' | 'tool'; // Agregamos 'tool' para las respuestas de herramientas
-  content: string;
-}
 
 interface WhatsAppMessagePayload {
   object: string;


### PR DESCRIPTION
## Summary
- remove unused ChatMessage interface definition
- clean up WhatsApp webhook controller interface comment

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a584f7830832aa2983c096411a7ee