### PR TITLE
Remove promptVentas asset references

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -3,11 +3,6 @@
   "collection": "@nestjs/schematics",
   "sourceRoot": "src",
   "compilerOptions": {
-    "deleteOutDir": true,
-    "assets": [{
-      "include": "src/mcp/mcp/promptVentas.json",
-      "outDir": "dist/mcp/mcp"
-
-    }]
+    "deleteOutDir": true
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 {
   "extends": "./tsconfig.json",
   "exclude": ["node_modules", "test", "dist", "**/*spec.ts"],
-  "include": ["src/**/*.ts", "src/mcp//mcp/promptVentas.json"]
+  "include": ["src/**/*.ts"]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,6 @@
 // webpack.config.js
 const nodeExternals = require('webpack-node-externals');
 const { RunScriptWebpackPlugin } = require('run-script-webpack-plugin');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
-const path = require('path');
 
 module.exports = function (options, webpack) {
   return {
@@ -13,24 +11,13 @@ module.exports = function (options, webpack) {
         allowlist: ['webpack/hot/poll?100'],
       }),
     ],
-    plugins: [
-      // ① Copiamos promptVentas.json desde src/mcp a dist/mcp
-      new CopyWebpackPlugin({
-        patterns: [
-          {
-            from: path.resolve(__dirname, 'src', 'mcp', 'promptVentas.json'),
-            // 'to' relativo al output.path (por defecto dist/)
-            to: 'mcp/promptVentas.json',
-          },
-        ],
-      }),
-
-      ...options.plugins,
-      new webpack.HotModuleReplacementPlugin(),
-      new webpack.WatchIgnorePlugin({
-        paths: [/\.js$/, /\.d\.ts$/],
-      }),
-      new RunScriptWebpackPlugin({
+      plugins: [
+        ...options.plugins,
+        new webpack.HotModuleReplacementPlugin(),
+        new webpack.WatchIgnorePlugin({
+          paths: [/\.js$/, /\.d\.ts$/],
+        }),
+        new RunScriptWebpackPlugin({
         name: options.output.filename,
         autoRestart: false,
       }),


### PR DESCRIPTION
## Summary
- remove `promptVentas.json` asset entry from Nest builder config
- delete JSON include in `tsconfig.build.json`
- drop copy plugin config in `webpack.config.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5842f0b8832a99ee53c5ebdc0a6c