### PR TITLE
refactor: return slots synchronously

### DIFF
--- a/src/database/dynamo/dynamo.service.spec.ts
+++ b/src/database/dynamo/dynamo.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { DynamoService } from './dynamo.service';
+import { ConfigService } from '@nestjs/config';
 
 describe('DynamoService', () => {
   let service: DynamoService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [DynamoService],
+      providers: [
+        DynamoService,
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn() },
+        },
+      ],
     }).compile();
 
     service = module.get<DynamoService>(DynamoService);
@@ -14,5 +21,11 @@ describe('DynamoService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('generarSlots should return an array of slots without Promise', () => {
+    const slots = service.generarSlots(8, 10, 60, 12, 13, '2024-01-01');
+    expect(Array.isArray(slots)).toBe(true);
+    expect(slots).not.toBeInstanceOf(Promise);
   });
 });

--- a/src/database/dynamo/dynamo.service.ts
+++ b/src/database/dynamo/dynamo.service.ts
@@ -69,15 +69,15 @@ export class DynamoService {
     }
   }
 
-  async generarSlots(
+  generarSlots(
     startHour: number,
     endHour: number,
     slotDuration: number,
     breakStart: number,
     breakEnd: number,
     fecha: string,
-  ) {
-    const slots = [] as string[];
+  ): string[] {
+    const slots: string[] = [];
 
     let current = moment
       .tz(fecha, 'America/Bogota')
@@ -167,7 +167,7 @@ export class DynamoService {
       fecha,
     );
     const ocupadas = await this.obtenerCitasOcupadas(psicologo.id, fecha);
-    return (await slots)
+    return slots
       .filter((slot) => !ocupadas.has(slot))
       .map((slot) => {
         const date = new Date(slot);


### PR DESCRIPTION
## Summary
- make `generarSlots` synchronous and return a string array
- consume slots directly in `obtenerHuecosDisponibles`
- cover `generarSlots` with a unit test for synchronous behavior

## Testing
- `npm test` *(fails: Cannot find module or resolve ConfigService for multiple services)*
- `npm test src/database/dynamo/dynamo.service.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_6897a416c0d8832a8753d1d22658a2c9